### PR TITLE
Update folder names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Displays and disabled interfaces (== readonly) support a custom click-action. Th
 
 ## ⚙️ Installation
 1. Download the `display-index.js` and `interface-index.js` from the [latest release](https://github.com/utomic-media/directus-extension-field-actions/releases)
-2. Create a folder named `field-actions` in your displays- as well as interfaces-extension folder (e.g  `/extensions/displays/fields-action` and `/extensions/interfaces/fields-action`)
+2. Create a folder named `field-actions` in your displays- as well as interfaces-extension folder (e.g  `/extensions/displays/field-actions` and `/extensions/interfaces/field-actions`)
 3. Move the downloaded release files each to the folder and rename each of them into `index.js`
 4. Restart directus
 


### PR DESCRIPTION
There was some inconsistency in the folder name examples that I fixed to match the instructions. 

The correct name for the folders is: `field-actions`.