### PR TITLE
Feat/dynamic.action icon position

### DIFF
--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -19,9 +19,9 @@
 		<v-icon 
 			v-if="showCopy && isCopySupported"
 			name="content_copy"
-			right
 			v-tooltip="`Copy to clipboard: ${value}`"
 			@click.stop="copyValue"
+			:class="copyPosition === 'start' ? '-order-1' : 'order-1'"
 		/>
 		
 
@@ -32,10 +32,10 @@
 			rel="noopener noreferrer"
 			v-tooltip="`Follow link: ${computedLink}`"
 			@click.stop
+			:class="linkPosition === 'start' ? '-order-1' : 'order-1'"
 		>
 			<v-icon 
 				name="open_in_new"
-				right
 			/>
 		</a>
 	</span>
@@ -75,9 +75,17 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	copyPosition: {
+		type: String,
+		default: 'end',
+	},
 	showLink: {
 		type: Boolean,
 		default: false,
+	},
+	linkPosition: {
+		type: String,
+		default: 'end',
 	},
 });
 
@@ -128,6 +136,25 @@ const actionTooltip = computed(() => {
 
 <style lang="scss" scoped>
 	.action-display {
+		display: flex;
+    flex-direction: row;
+    align-items: center;
+
+		span,
+		a {
+			display: inherit;
+
+			&.order-1 {
+				order: 1;
+				margin-left: 8px;
+			}
+
+			&.-order-1 {
+				order: -1;
+				margin-right: 8px;
+			}
+		}
+
 		:deep(.v-icon) {
 			--v-icon-size: 18px;
 			--v-icon-color: var(--border-normal-alt);

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -29,6 +29,8 @@
 			v-tooltip="value ? `Copy to clipboard: ${value}` : `Can't copy empty value`"
 			icon
 			secondary
+			xLarge
+			:class="copyPosition === 'start' ? '-order-1' : 'order-1'"
 		>
 			<v-icon
 				name="content_copy"
@@ -44,6 +46,8 @@
 			v-tooltip="value ? `Follow link: ${computedLink}` : `Can't follow empty link`"
 			icon
 			secondary
+			xLarge
+			:class="linkPosition === 'start' ? '-order-1' : 'order-1'"
 		>
 			<a 
 				:href="computedLink"
@@ -82,9 +86,17 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+	copyPosition: {
+		type: String,
+		default: 'end',
+	},
 	showLink: {
 		type: Boolean,
 		default: false,
+	},
+	linkPosition: {
+		type: String,
+		default: 'end',
 	},
 	placeholder: {
 		type: String,
@@ -164,8 +176,18 @@ function valueClickAction(e: Event) {
 	flex-direction: row;
 	align-items: center;
 
-	.v-button {
-		margin-left: 1rem;
+	>div {
+		display: inherit;
+
+		&.order-1 {
+			order: 1;
+			margin-left: 8px;
+		}
+
+		&.-order-1 {
+			order: -1;
+			margin-right: 8px;
+		}
 	}
 }
 </style>

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -33,6 +33,24 @@ export function getSharedConfigOptions(isString: boolean) {
         default_value: false,
       },
     },
+    {
+      field: 'copyPosition',
+      name: 'Copy icon position',
+      type: 'string',
+      meta: {
+        width: 'half',
+        interface: 'select-radio',
+        options: {
+          choices: [
+            { text: 'Start', value: 'start' },
+            { text: 'End', value: 'end' }
+          ],
+        },
+      },
+      schema: {
+        default_value: 'end',
+      },
+    },
     // TODO: allow option only when "contentType" is one of "phone, url or email" --> and set true in this cases
     {
       field: 'showLink',
@@ -47,6 +65,24 @@ export function getSharedConfigOptions(isString: boolean) {
       },
       schema: {
         default_value: false,
+      },
+    },
+    {
+      field: 'linkPosition',
+      name: 'Link icon position',
+      type: 'string',
+      meta: {
+        width: 'half',
+        interface: 'select-radio',
+        options: {
+          choices: [
+            { text: 'Start', value: 'start' },
+            { text: 'End', value: 'end' }
+          ],
+        },
+      },
+      schema: {
+        default_value: 'end',
       },
     },
   ];


### PR DESCRIPTION
Adds new options to the display + interface to select the icon / button position.
Link and copy buttons can now be placed before the content.

This also fixes the button-height in the interface (previously the button was smaller than the input)

closes #7 

![Bildschirm­foto 2023-03-14 um 13 44 13](https://user-images.githubusercontent.com/46492597/225004987-94d50e2e-3e26-4f71-b953-5e632b6f1685.png)
![Bildschirm­foto 2023-03-14 um 13 44 25](https://user-images.githubusercontent.com/46492597/225004990-91b05b1f-a4e5-42ba-abfd-373686708f2e.png)
![Bildschirm­foto 2023-03-14 um 13 44 38](https://user-images.githubusercontent.com/46492597/225004991-a825ff2e-395f-4f7c-bb6c-33e4edfc805a.png)
