### PR TITLE
Fix/unified link targets

### DIFF
--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -117,6 +117,11 @@ function valueClickAction(e: Event) {
 		e.stopPropagation();
 		copyValue();
 	} 
+
+	if (props.clickAction === 'link') {
+		// We opened a link in a new tab and don't want to get into the details view of the item
+		e.stopPropagation();
+	}
 	// else go on with the default events
 }
 

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -6,6 +6,8 @@
 			class="dynamic-wrapper"
 			:href="computedLink"
 			v-tooltip.left="actionTooltip"
+			target="_blank"
+			rel="noopener noreferrer"
 		>
 			<span 
 				:class="hasValueClickAction ? 'action-background' : ''"

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -166,6 +166,12 @@ function valueClickAction(e: Event) {
 		e.stopPropagation();
 		copyValue();
 	} 
+
+	if (props.clickAction === 'link' && props.disabled && props.value) {
+		e.stopPropagation();
+		window.open(computedLink.value, '_blank', 'noopener, noreferrer');
+	}
+	
 	// else go on with the default events
 }
 


### PR DESCRIPTION
- Always open links in a new tab
- Don't open item when the display is used as a link
- Add missing feature: disabled interface use linkAction

Fixes #26 and #28 