### PR TITLE
Add option to configure opening link as new tab or current tab

### DIFF
--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -6,7 +6,7 @@
 			class="dynamic-wrapper"
 			:href="computedLink"
 			v-tooltip.left="actionTooltip"
-			target="_blank"
+			:target="openLinkAsNewTab ? '_blank' : '_self'"
 			rel="noopener noreferrer"
 		>
 			<span 
@@ -30,7 +30,7 @@
 		<a 
 			v-if="showLink"
 			:href="computedLink"
-			target="_blank"
+			:target="openLinkAsNewTab ? '_blank' : '_self'"
 			rel="noopener noreferrer"
 			v-tooltip="`Follow link: ${prefix}${computedLink}`"
 			@click.stop
@@ -94,6 +94,10 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
+  openLinkAsNewTab: {
+    type: Boolean,
+    default: true
+  }
 });
 
 

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -51,7 +51,7 @@
 		>
 			<a 
 				:href="computedLink"
-				target="_blank"
+				:target="openLinkAsNewTab ? '_blank' : '_self'"
 				rel="noopener noreferrer"
 				@click.stop
 			>
@@ -136,6 +136,10 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
+  openLinkAsNewTab: {
+    type: Boolean,
+    default: true
+  }
 });
 
 const emit = defineEmits(['input']);

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -115,6 +115,24 @@ export function getSharedConfigOptions(isString: boolean) {
         default_value: '',
       },
     },
+    {
+      field: 'openLinkAsNewTab',
+      name: 'Open Link',
+      type: 'boolean',
+      meta: {
+        width: 'full',
+        interface: 'select-radio',
+        options: {
+          choices: [
+            { text: 'As New Tab', value: true },
+            { text: 'On Current Tab', value: false }
+          ],
+        },
+      },
+      schema: {
+        default_value: true,
+      },
+    },
   ];
 
   return options;


### PR DESCRIPTION
This PR includes:
Add option to configure opening link as new tab or current tab
#Interface
![image](https://user-images.githubusercontent.com/36828138/236688090-ed594b06-aff0-4dc1-854f-ad75675af5de.png)

#Display
![image](https://user-images.githubusercontent.com/36828138/236688130-03c225f8-68b3-4cb6-a753-ed6f51d31a3b.png)

Close #30