### PR TITLE
FIX: Set IDs closes #32

### DIFF
--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -3,7 +3,7 @@ import DisplayComponent from './display.vue';
 import { getSharedConfigOptions, getClickActionChoices } from '../shared/options/sharedConfigOptions';
 
 export default defineDisplay({
-	id: 'custom',
+	id: 'field-actions',
 	name: 'Action display',
 	icon: 'ads_click',
 	description: 'Display content with actions like linking or copy to clipboard. (By clicking on the content (only at readonly) and seperate buttons)! NOTE: the content needs to match the schema',

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -3,7 +3,7 @@ import InterfaceComponent from './interface.vue';
 import { getSharedConfigOptions, getClickActionChoices } from '../shared/options/sharedConfigOptions';
 
 export default defineInterface({
-	id: 'custom',
+	id: 'field-actions',
 	name: 'Action interface',
 	icon: 'ads_click',
 	description: 'Display content with actions like linking or copy to clipboard. (By clicking on the content (only at readonly) and seperate buttons)! NOTE: the content needs to match the schema',


### PR DESCRIPTION
⚠️ This sets a new ID for the interface + display (previous: `custom` --> now: `field-actions`)

Need to update your field config. This can either be done via:
- UI (the settings should be kept if you re-select the field-actions interface / display)
- In the DB (Table: `directus_fields` --> check for fields with interface / display `custom` and replace those with `field-actions`. Make sure to only update fields that should use the field-acitons)

As always make sure to backup the database before