### PR TITLE
Fix double prefix in link tooltip

### DIFF
--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -24,7 +24,7 @@
 			outlined
 			small
 			:class="copyPosition === 'start' ? '-order-1' : 'order-1'"
-			v-tooltip="`Copy: ${prefix}${value}`"
+			v-tooltip="`Copy: ${computedLink}`"
 			@click.stop="copyValue"
 		>
 			<v-icon 
@@ -64,7 +64,6 @@
 import { computed } from 'vue';
 import { useClipboard } from '../shared/composable/use-clipboard';
 import { useLink } from '../shared/composable/use-link';
-import { usePrefix } from '../shared/composable/use-prefix';
 import { useStores } from '@directus/extensions-sdk';
 
 const props = defineProps({
@@ -133,11 +132,10 @@ const { useNotificationsStore } = useStores();
 const notificationStore = useNotificationsStore();	
 
 const { computedLink } = useLink(props);
-const prefix = usePrefix(props.copyPrefix);
 
 
 async function copyValue() {
-	await copyToClipboard(`${prefix.value}${props.value}`, notificationStore);
+	await copyToClipboard(computedLink.value, notificationStore);
 };
 
 

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -44,7 +44,7 @@
 			:href="computedLink"
 			:target="openLinkAsNewTab ? '_blank' : '_self'"
 			rel="noopener noreferrer"
-			v-tooltip="`Follow link: ${prefix}${computedLink}`"
+			v-tooltip="`Follow link: ${computedLink}`"
 			@click.stop
 			:class="linkPosition === 'start' ? '-order-1' : 'order-1'"
 		>

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -26,7 +26,7 @@
 		<v-button
 			v-if="showCopy && isCopySupported"
 			:disabled="!value"
-			v-tooltip="value ? `Copy: ${prefix}${value}` : `Can't copy empty value`"
+			v-tooltip="value ? `Copy: ${computedLink}` : `Can't copy empty value`"
 			icon
 			secondary
 			xLarge
@@ -68,7 +68,6 @@ import { computed } from 'vue';
 import { useClipboard } from '../shared/composable/use-clipboard';
 import { useLink } from '../shared/composable/use-link';
 import { useStores } from '@directus/extensions-sdk';
-import { usePrefix } from '../shared/composable/use-prefix';
 
 const props = defineProps({
 	value: {
@@ -150,7 +149,6 @@ const { useNotificationsStore } = useStores();
 const notificationStore = useNotificationsStore();	
 
 const { computedLink } = useLink(props);
-const prefix = usePrefix(props.copyPrefix);
 
 
 const inputType = computed(() => {
@@ -160,7 +158,7 @@ const inputType = computed(() => {
 
 
 async function copyValue() {
-	await copyToClipboard(`${prefix.value}${props.value}`, notificationStore);
+	await copyToClipboard(`${computedLink.value}`, notificationStore);
 };
 
 

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -43,7 +43,7 @@
 		<v-button
 			v-if="showLink"
 			:disabled="!value"
-			v-tooltip="value ? `Follow link: ${prefix}${computedLink}` : `Can't follow empty link`"
+			v-tooltip="value ? `Follow link: ${computedLink}` : `Can't follow empty link`"
 			icon
 			secondary
 			xLarge


### PR DESCRIPTION
Link component's tooltip adds copy's prefix in front of the `computedLink`, which already contains the link prefix: `Follow link: ${prefix}${computedLink}`

The `href` attribute is proper: `:href="computedLink"`.

In my example `https://youtu.be/` is the prefix for both copy and link, and we see that the link's href is correct, but the tooltip is not:
![image](https://github.com/utomic-media/directus-extension-field-actions/assets/6065071/71f72599-a145-4f28-8179-bd8f3cb40a78)
