### PR TITLE
FIX 41: use copy prefix for copy actions

### DIFF
--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -24,7 +24,7 @@
 			outlined
 			small
 			:class="copyPosition === 'start' ? '-order-1' : 'order-1'"
-			v-tooltip="`Copy: ${computedLink}`"
+			v-tooltip="`Copy: ${computedCopyValue}`"
 			@click.stop="copyValue"
 		>
 			<v-icon 
@@ -63,7 +63,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useClipboard } from '../shared/composable/use-clipboard';
-import { useLink } from '../shared/composable/use-link';
+import { usePrefixedValues } from '../shared/composable/use-prefixed-values';
 import { useStores } from '@directus/extensions-sdk';
 
 const props = defineProps({
@@ -131,11 +131,11 @@ const { isCopySupported, copyToClipboard } = useClipboard();
 const { useNotificationsStore } = useStores();
 const notificationStore = useNotificationsStore();	
 
-const { computedLink } = useLink(props);
+const { computedLink, computedCopyValue } = usePrefixedValues(props);
 
 
 async function copyValue() {
-	await copyToClipboard(computedLink.value, notificationStore);
+	await copyToClipboard(computedCopyValue.value, notificationStore);
 };
 
 

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -26,7 +26,7 @@
 		<v-button
 			v-if="showCopy && isCopySupported"
 			:disabled="!value"
-			v-tooltip="value ? `Copy: ${computedLink}` : `Can't copy empty value`"
+			v-tooltip="value ? `Copy: ${computedCopyValue}` : `Can't copy empty value`"
 			icon
 			secondary
 			xLarge
@@ -66,7 +66,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { useClipboard } from '../shared/composable/use-clipboard';
-import { useLink } from '../shared/composable/use-link';
+import { usePrefixedValues } from '../shared/composable/use-prefixed-values';
 import { useStores } from '@directus/extensions-sdk';
 
 const props = defineProps({
@@ -148,7 +148,7 @@ const { isCopySupported, copyToClipboard } = useClipboard();
 const { useNotificationsStore } = useStores();
 const notificationStore = useNotificationsStore();	
 
-const { computedLink } = useLink(props);
+const { computedLink, computedCopyValue } = usePrefixedValues(props);
 
 
 const inputType = computed(() => {
@@ -158,7 +158,7 @@ const inputType = computed(() => {
 
 
 async function copyValue() {
-	await copyToClipboard(`${computedLink.value}`, notificationStore);
+	await copyToClipboard(`${computedCopyValue.value}`, notificationStore);
 };
 
 

--- a/src/shared/composable/use-prefixed-values.ts
+++ b/src/shared/composable/use-prefixed-values.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue';
 import { usePrefix } from './use-prefix';
 
-export function useLink(props: any) {
+export function usePrefixedValues(props: any) {
 
   // TODO: make sure it's always a valid link (absolute + relative)
 
@@ -10,5 +10,10 @@ export function useLink(props: any) {
     return prefix.value + props.value;
   });
 
-  return { computedLink };
+  const computedCopyValue = computed(() => { 
+    const prefix = usePrefix(props.copyPrefix);
+    return prefix.value + props.value;
+  });
+
+  return { computedLink, computedCopyValue };
 }


### PR DESCRIPTION
Fix: #41
The copy action has used the computed link in both display and interface. This provides a fix to use the correct 'copy-prefix' for the copy actions