### PR TITLE
Consider URLs with leading slashes as internal without crashing.

### DIFF
--- a/src/shared/components/linkWrapper.vue
+++ b/src/shared/components/linkWrapper.vue
@@ -61,7 +61,7 @@ const activeDialog = ref(false);
 
 
 function handleClick(e: MouseEvent) {
-  const isExternal = new URL(props.href).origin !== window.location.origin;
+  const isExternal = !props.href.startsWith('/') && new URL(props.href).origin !== window.location.origin;
 
   if (props.safeMode && isExternal) {
     activeDialog.value = true;


### PR DESCRIPTION
We use domain-relative URLs with leading slashes with this extension.

Eg: `/my-article` instead of `https://mysite/my-article`. This causes this extension to crash with the latest release, as attempting to create a `new URL()` with an absolute path rather than a full URI will cause the extension to crash. 

This PR checks for a leading slash and bypasses the `isExternal` check if present, avoiding constructing a URL object for same-domain-relative URLs.