### PR TITLE
feat: add customizable tooltip labels for copy and open link actions

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,10 +53,12 @@
   "homepage": "https://github.com/utomic-media/directus-extension-field-actions.git#readme",
   "devDependencies": {
     "@directus/extensions-sdk": "^16.0.1",
+    "@directus/types": "^13.2.2",
     "sass": "^1.91.0",
     "sass-loader": "^16.0.5",
     "typescript": "^5.9.2",
-    "vue": "^3.5.20"
+    "vue": "^3.5.20",
+    "vue-i18n": "^11.1.11"
   },
   "files": [
     "dist/**/*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@directus/extensions-sdk':
         specifier: ^16.0.1
         version: 16.0.1(@types/node@24.3.0)(@unhead/vue@1.9.4(vue@3.5.20(typescript@5.9.2)))(knex@3.1.0)(pinia@2.1.7(typescript@5.9.2)(vue@3.5.20(typescript@5.9.2)))(sass@1.91.0)(terser@5.43.1)(typescript@5.9.2)
+      '@directus/types':
+        specifier: ^13.2.2
+        version: 13.2.2(knex@3.1.0)(vue@3.5.20(typescript@5.9.2))
       sass:
         specifier: ^1.91.0
         version: 1.91.0
@@ -23,6 +26,9 @@ importers:
       vue:
         specifier: ^3.5.20
         version: 3.5.20(typescript@5.9.2)
+      vue-i18n:
+        specifier: ^11.1.11
+        version: 11.1.11(vue@3.5.20(typescript@5.9.2))
 
 packages:
 
@@ -427,6 +433,18 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+
+  '@intlify/core-base@11.1.11':
+    resolution: {integrity: sha512-1Z0N8jTfkcD2Luq9HNZt+GmjpFe4/4PpZF3AOzoO1u5PTtSuXZcfhwBatywbfE2ieB/B5QHIoOFmCXY2jqVKEQ==}
+    engines: {node: '>= 16'}
+
+  '@intlify/message-compiler@11.1.11':
+    resolution: {integrity: sha512-7PC6neomoc/z7a8JRjPBbu0T2TzR2MQuY5kn2e049MP7+o32Ve7O8husylkA7K9fQRe4iNXZWTPnDJ6vZdtS1Q==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.1.11':
+    resolution: {integrity: sha512-RIBFTIqxZSsxUqlcyoR7iiC632bq7kkOwYvZlvcVObHfrF4NhuKc4FKvu8iPCrEO+e3XsY7/UVpfgzg+M7ETzA==}
+    engines: {node: '>= 16'}
 
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
@@ -2023,6 +2041,12 @@ packages:
       '@vue/composition-api':
         optional: true
 
+  vue-i18n@11.1.11:
+    resolution: {integrity: sha512-LvyteQoXeQiuILbzqv13LbyBna/TEv2Ha+4ZWK2AwGHUzZ8+IBaZS0TJkCgn5izSPLcgZwXy9yyTrewCb2u/MA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      vue: ^3.0.0
+
   vue@3.5.18:
     resolution: {integrity: sha512-7W4Y4ZbMiQ3SEo+m9lnoNpV9xG7QVMLa+/0RFwwiAVkeYoyGXqWE85jabU4pllJNUzqfLShJ5YLptewhCWUgNA==}
     peerDependencies:
@@ -2225,6 +2249,28 @@ snapshots:
     optionalDependencies:
       knex: 3.1.0
       vue: 3.5.18(typescript@5.9.2)
+    transitivePeerDependencies:
+      - better-sqlite3
+      - mysql
+      - mysql2
+      - pg
+      - pg-native
+      - sqlite3
+      - supports-color
+      - tedious
+
+  '@directus/types@13.2.2(knex@3.1.0)(vue@3.5.20(typescript@5.9.2))':
+    dependencies:
+      '@directus/constants': 13.0.2
+      '@directus/schema': 13.0.2
+      '@sinclair/typebox': 0.34.38
+      '@types/express': 4.17.21
+      '@types/geojson': 7946.0.16
+      '@types/nodemailer': 6.4.17
+      '@types/ws': 8.18.1
+    optionalDependencies:
+      knex: 3.1.0
+      vue: 3.5.20(typescript@5.9.2)
     transitivePeerDependencies:
       - better-sqlite3
       - mysql
@@ -2454,6 +2500,18 @@ snapshots:
   '@inquirer/type@3.0.8(@types/node@24.3.0)':
     optionalDependencies:
       '@types/node': 24.3.0
+
+  '@intlify/core-base@11.1.11':
+    dependencies:
+      '@intlify/message-compiler': 11.1.11
+      '@intlify/shared': 11.1.11
+
+  '@intlify/message-compiler@11.1.11':
+    dependencies:
+      '@intlify/shared': 11.1.11
+      source-map-js: 1.2.1
+
+  '@intlify/shared@11.1.11': {}
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
@@ -3956,6 +4014,13 @@ snapshots:
 
   vue-demi@0.14.10(vue@3.5.20(typescript@5.9.2)):
     dependencies:
+      vue: 3.5.20(typescript@5.9.2)
+
+  vue-i18n@11.1.11(vue@3.5.20(typescript@5.9.2)):
+    dependencies:
+      '@intlify/core-base': 11.1.11
+      '@intlify/shared': 11.1.11
+      '@vue/devtools-api': 6.6.4
       vue: 3.5.20(typescript@5.9.2)
 
   vue@3.5.18(typescript@5.9.2):

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -111,7 +111,7 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	copyTooltip: {
+	customCopyTooltip: {
 		type: String,
 		default: null,
 	},
@@ -135,7 +135,7 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	linkTooltip: {
+	customLinkTooltip: {
 		type: String,
 		default: null,
 	},
@@ -164,9 +164,9 @@ const { computedLink, computedCopyValue } = usePrefixedValues(props);
 const { copyTooltip, linkTooltip, actionTooltip } = useTooltips({
 	clickAction: props.clickAction,
 	useCustomCopyTooltip: props.useCustomCopyTooltip,
-	copyTooltip: props.copyTooltip,
+	customCopyTooltip: props.customCopyTooltip,
 	useCustomLinkTooltip: props.useCustomLinkTooltip,
-	linkTooltip: props.linkTooltip,
+	customLinkTooltip: props.customLinkTooltip,
 });
 
 

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -18,6 +18,8 @@
 				{{ value }}
 			</span>
 		</component>
+
+		
 		
 		<component
 			v-if="showCopy && isCopySupported"
@@ -25,7 +27,7 @@
 			outlined
 			xSmall
 			:class="copyPosition === 'start' ? '-order-1' : 'order-1'"
-			v-tooltip="`Copy: ${computedCopyValue}`"
+			v-tooltip="copyTooltipLabel || `Copy: ${computedCopyValue}`"
 			@click.stop="copyValue"
 		>
 			<v-icon 
@@ -50,7 +52,7 @@
 				:is="(linkButtonLabel) ? 'v-button' : 'div'" 
 				outlined
 				xSmall
-				v-tooltip="`Follow link: ${computedLink}`"
+				v-tooltip="openLinkTooltipLabel || `Follow link: ${computedLink}`"
 			>
 				<v-icon 
 					name="open_in_new"
@@ -105,6 +107,10 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
+	copyTooltipLabel: {
+		type: String,
+		default: '',
+	},
 	copyButtonLabel: {
 		type: String,
 		default: '',
@@ -122,6 +128,10 @@ const props = defineProps({
 		default: '',
 	},
 	linkButtonLabel: {
+		type: String,
+		default: '',
+	},
+	openLinkTooltipLabel: {
 		type: String,
 		default: '',
 	},
@@ -170,8 +180,8 @@ const hasValueClickAction = computed(() => {
 
 // TODO: move in composable (together with display)
 const actionTooltip = computed(() => {
-	if (props.clickAction === 'copy' && isCopySupported) return 'Copy value';
-	if (props.clickAction === 'link') return 'Open link';
+	if (props.clickAction === 'copy' && isCopySupported) return props.copyTooltipLabel || 'Copy value';
+	if (props.clickAction === 'link') return props.openLinkTooltipLabel || 'Open link';
 });
 
 </script>

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -52,7 +52,7 @@
 				:is="(linkButtonLabel) ? 'v-button' : 'div'" 
 				outlined
 				xSmall
-				v-tooltip="openLinkTooltipLabel || `Follow link: ${computedLink}`"
+				v-tooltip="linkTooltipLabel || `Follow link: ${computedLink}`"
 			>
 				<v-icon 
 					name="open_in_new"
@@ -131,7 +131,7 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
-	openLinkTooltipLabel: {
+	linkTooltipLabel: {
 		type: String,
 		default: '',
 	},
@@ -181,7 +181,7 @@ const hasValueClickAction = computed(() => {
 // TODO: move in composable (together with display)
 const actionTooltip = computed(() => {
 	if (props.clickAction === 'copy' && isCopySupported) return props.copyTooltipLabel || 'Copy value';
-	if (props.clickAction === 'link') return props.openLinkTooltipLabel || 'Open link';
+	if (props.clickAction === 'link') return props.linkTooltipLabel || 'Open link';
 });
 
 </script>

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -105,7 +105,6 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
-	
 	copyButtonLabel: {
 		type: String,
 		default: '',

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -163,8 +163,10 @@ const { computedLink, computedCopyValue } = usePrefixedValues(props);
 
 const { copyTooltip, linkTooltip, actionTooltip } = useTooltips({
 	clickAction: props.clickAction,
-	useCustomTooltip: props.useCustomCopyTooltip,
-	customTooltip: props.copyTooltip,
+	useCustomCopyTooltip: props.useCustomCopyTooltip,
+	copyTooltip: props.copyTooltip,
+	useCustomLinkTooltip: props.useCustomLinkTooltip,
+	linkTooltip: props.linkTooltip,
 });
 
 

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -18,8 +18,6 @@
 				{{ value }}
 			</span>
 		</component>
-
-		
 		
 		<component
 			v-if="showCopy && isCopySupported"

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -25,7 +25,7 @@
 			outlined
 			xSmall
 			:class="copyPosition === 'start' ? '-order-1' : 'order-1'"
-			v-tooltip="`Copy: ${computedCopyValue}`"
+			v-tooltip="copyTooltip"
 			@click.stop="copyValue"
 		>
 			<v-icon 
@@ -50,7 +50,7 @@
 				:is="(linkButtonLabel) ? 'v-button' : 'div'" 
 				outlined
 				xSmall
-				v-tooltip="`Follow link: ${computedLink}`"
+				v-tooltip="linkTooltip"
 			>
 				<v-icon 
 					name="open_in_new"
@@ -66,11 +66,13 @@
 
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, PropType } from 'vue';
 import { useClipboard } from '../shared/composable/use-clipboard';
 import { usePrefixedValues } from '../shared/composable/use-prefixed-values';
 import { useStores } from '@directus/extensions-sdk';
 import linkWrapper from '../shared/components/linkWrapper.vue';
+import { useTooltips } from '../shared/composable/use-tooltips';
+import type { ClickAction } from '../shared/types';
 
 const props = defineProps({
 	value: {
@@ -90,7 +92,7 @@ const props = defineProps({
 		default: false,
 	},
 	clickAction: {
-		type: String,
+		type: String as PropType<ClickAction>,
 		default: 'default',
 	},
 	showCopy: {
@@ -104,6 +106,14 @@ const props = defineProps({
 	copyPrefix: {
 		type: String,
 		default: '',
+	},
+	useCustomCopyTooltip: {
+		type: Boolean,
+		default: false,
+	},
+	copyTooltip: {
+		type: String,
+		default: null,
 	},
 	copyButtonLabel: {
 		type: String,
@@ -120,6 +130,14 @@ const props = defineProps({
 	linkPrefix: {
 		type: String,
 		default: '',
+	},
+	useCustomLinkTooltip: {
+		type: Boolean,
+		default: false,
+	},
+	linkTooltip: {
+		type: String,
+		default: null,
 	},
 	linkButtonLabel: {
 		type: String,
@@ -142,6 +160,12 @@ const { useNotificationsStore } = useStores();
 const notificationStore = useNotificationsStore();	
 
 const { computedLink, computedCopyValue } = usePrefixedValues(props);
+
+const { copyTooltip, linkTooltip, actionTooltip } = useTooltips({
+	clickAction: props.clickAction,
+	useCustomTooltip: props.useCustomCopyTooltip,
+	customTooltip: props.copyTooltip,
+});
 
 
 async function copyValue() {
@@ -166,14 +190,6 @@ const hasValueClickAction = computed(() => {
 
 	return false;
 });
-
-
-// TODO: move in composable (together with display)
-const actionTooltip = computed(() => {
-	if (props.clickAction === 'copy' && isCopySupported) return 'Copy value';
-	if (props.clickAction === 'link') return 'Open link';
-});
-
 </script>
 
 

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -25,7 +25,7 @@
 			outlined
 			xSmall
 			:class="copyPosition === 'start' ? '-order-1' : 'order-1'"
-			v-tooltip="copyTooltipLabel || `Copy: ${computedCopyValue}`"
+			v-tooltip="`Copy: ${computedCopyValue}`"
 			@click.stop="copyValue"
 		>
 			<v-icon 
@@ -50,7 +50,7 @@
 				:is="(linkButtonLabel) ? 'v-button' : 'div'" 
 				outlined
 				xSmall
-				v-tooltip="linkTooltipLabel || `Follow link: ${computedLink}`"
+				v-tooltip="`Follow link: ${computedLink}`"
 			>
 				<v-icon 
 					name="open_in_new"
@@ -105,10 +105,7 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
-	copyTooltipLabel: {
-		type: String,
-		default: '',
-	},
+	
 	copyButtonLabel: {
 		type: String,
 		default: '',
@@ -126,10 +123,6 @@ const props = defineProps({
 		default: '',
 	},
 	linkButtonLabel: {
-		type: String,
-		default: '',
-	},
-	linkTooltipLabel: {
 		type: String,
 		default: '',
 	},
@@ -178,8 +171,8 @@ const hasValueClickAction = computed(() => {
 
 // TODO: move in composable (together with display)
 const actionTooltip = computed(() => {
-	if (props.clickAction === 'copy' && isCopySupported) return props.copyTooltipLabel || 'Copy value';
-	if (props.clickAction === 'link') return props.linkTooltipLabel || 'Open link';
+	if (props.clickAction === 'copy' && isCopySupported) return 'Copy value';
+	if (props.clickAction === 'link') return 'Open link';
 });
 
 </script>

--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -51,7 +51,7 @@ export default defineDisplay({
 				name: 'Copy button label',
 				type: 'string',
 				meta: {
-					width: 'half',
+					width: 'full',
 					interface: 'system-input-translated-string',
 					group: 'groupCopySettings',
 					note: 'When used the copy icon will be shown as button with the given label',
@@ -65,7 +65,7 @@ export default defineDisplay({
 				name: 'Link button label',
 				type: 'string',
 				meta: {
-					width: 'half',
+					width: 'full',
 					interface: 'system-input-translated-string',
 					group: 'groupLinkSettings',
 					note: 'When used the link icon will be shown as button with the given label',

--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -47,6 +47,20 @@ export default defineDisplay({
 
 		const customOptionsAfterShared = [
 			{
+				field: 'copyTooltipLabel',
+				name: 'Copy tooltip label',
+				type: 'string',
+				meta: {
+					width: 'half',
+					interface: 'system-input-translated-string',
+					group: 'groupCopySettings',
+					note: 'When used the message when hovering the field will be the given label',
+				},
+				schema: {
+					default_value: 'Copy value',
+				},
+			},
+			{
 				field: 'copyButtonLabel',
 				name: 'Copy button label',
 				type: 'string',
@@ -72,6 +86,20 @@ export default defineDisplay({
 				},
 				schema: {
 					default_value: '',
+				},
+			},
+			{
+				field: 'openLinkTooltipLabel',
+				name: 'Open link tooltip label',
+				type: 'string',
+				meta: {
+					width: 'half',
+					interface: 'system-input-translated-string',
+					group: 'groupLinkSettings',
+					note: 'When used the message when hovering the link will be the given label',
+				},
+				schema: {
+					default_value: 'Open link',
 				},
 			},
 		];

--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -47,20 +47,6 @@ export default defineDisplay({
 
 		const customOptionsAfterShared = [
 			{
-				field: 'copyTooltipLabel',
-				name: 'Copy tooltip label',
-				type: 'string',
-				meta: {
-					width: 'half',
-					interface: 'system-input-translated-string',
-					group: 'groupCopySettings',
-					note: 'When used the message when hovering the field will be the given label',
-				},
-				schema: {
-					default_value: 'Copy value',
-				},
-			},
-			{
 				field: 'copyButtonLabel',
 				name: 'Copy button label',
 				type: 'string',
@@ -72,20 +58,6 @@ export default defineDisplay({
 				},
 				schema: {
 					default_value: '',
-				},
-			},
-			{
-				field: 'linkTooltipLabel',
-				name: 'Link tooltip label',
-				type: 'string',
-				meta: {
-					width: 'half',
-					interface: 'system-input-translated-string',
-					group: 'groupLinkSettings',
-					note: 'When used the message when hovering the link will be the given label',
-				},
-				schema: {
-					default_value: 'Open link',
 				},
 			},
 			{

--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -12,7 +12,7 @@ export default defineDisplay({
 	options: ({ field }): any => {
 		const isString = ['string', 'text'].includes(field.type ?? 'unknown');
 
-		const sharedOptions = getSharedConfigOptions(field);
+		const sharedOptions = getSharedConfigOptions(field, 'display');
 
 		const customOptionsBeforeShared = [
 			{

--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -9,10 +9,10 @@ export default defineDisplay({
 	description: 'Display content with linking and copy to clipboard options',
 	component: DisplayComponent,
 	types: ['uuid', 'string', 'text', 'bigInteger', 'integer', 'decimal', 'float'],
-	options: ({ field  }): any => {
+	options: ({ field }): any => {
 		const isString = ['string', 'text'].includes(field.type ?? 'unknown');
 
-		const sharedOptions = getSharedConfigOptions(isString);
+		const sharedOptions = getSharedConfigOptions(field);
 
 		const customOptionsBeforeShared = [
 			{

--- a/src/display/index.ts
+++ b/src/display/index.ts
@@ -75,6 +75,20 @@ export default defineDisplay({
 				},
 			},
 			{
+				field: 'linkTooltipLabel',
+				name: 'Link tooltip label',
+				type: 'string',
+				meta: {
+					width: 'half',
+					interface: 'system-input-translated-string',
+					group: 'groupLinkSettings',
+					note: 'When used the message when hovering the link will be the given label',
+				},
+				schema: {
+					default_value: 'Open link',
+				},
+			},
+			{
 				field: 'linkButtonLabel',
 				name: 'Link button label',
 				type: 'string',
@@ -86,20 +100,6 @@ export default defineDisplay({
 				},
 				schema: {
 					default_value: '',
-				},
-			},
-			{
-				field: 'openLinkTooltipLabel',
-				name: 'Open link tooltip label',
-				type: 'string',
-				meta: {
-					width: 'half',
-					interface: 'system-input-translated-string',
-					group: 'groupLinkSettings',
-					note: 'When used the message when hovering the link will be the given label',
-				},
-				schema: {
-					default_value: 'Open link',
 				},
 			},
 		];

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -9,11 +9,11 @@ export default defineInterface({
 	description: 'Display content with linking and copy to clipboard options',
 	component: InterfaceComponent,
 	types: ['uuid', 'string', 'text', 'bigInteger', 'integer', 'decimal', 'float'],
-	options: ({ field  }): any => {
+	options: ({ field }): any => {
 		const isStringField 	= ['string', 'text'].includes(field.type ?? 'unknown');
 		const isNumericField 	= ['bigInteger', 'integer', 'float', 'decimal'].includes(field.type ?? 'unknown');
 
-		const sharedOptions = getSharedConfigOptions(isStringField);
+		const sharedOptions = getSharedConfigOptions(field);
 		// TODO: add custom options: softLength, clear, font
 		
 		const interfaceOptions = [

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -13,7 +13,7 @@ export default defineInterface({
 		const isStringField 	= ['string', 'text'].includes(field.type ?? 'unknown');
 		const isNumericField 	= ['bigInteger', 'integer', 'float', 'decimal'].includes(field.type ?? 'unknown');
 
-		const sharedOptions = getSharedConfigOptions(field);
+		const sharedOptions = getSharedConfigOptions(field, 'interface');
 		// TODO: add custom options: softLength, clear, font
 		
 		const interfaceOptions = [

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -32,7 +32,7 @@
 		<v-button
 			v-if="showCopy && isCopySupported"
 			:disabled="!value"
-			v-tooltip="value ? `Copy: ${computedCopyValue}` : `Can't copy empty value`"
+			v-tooltip="copyTooltip"
 			icon
 			secondary
 			xLarge
@@ -54,7 +54,7 @@
 			<v-button
 				v-if="showLink"
 				:disabled="!value"
-				v-tooltip="value ? `Follow link: ${computedLink}` : `Can't follow empty link`"
+				v-tooltip="linkTooltip"
 				icon
 				secondary
 				xLarge
@@ -68,11 +68,13 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, PropType } from 'vue';
 import { useClipboard } from '../shared/composable/use-clipboard';
 import { usePrefixedValues } from '../shared/composable/use-prefixed-values';
 import { useStores } from '@directus/extensions-sdk';
 import linkWrapper from '../shared/components/linkWrapper.vue';
+import { useTooltips } from '../shared/composable/use-tooltips';
+import type { ClickAction } from '../shared/types';
 
 const props = defineProps({
 	value: {
@@ -80,7 +82,7 @@ const props = defineProps({
 		default: null,
 	},
 	clickAction: {
-		type: String,
+		type: String as PropType<ClickAction>,
 		default: 'default',
 	},
 	showCopy: {
@@ -95,6 +97,14 @@ const props = defineProps({
 		type: String,
 		default: '',
 	},
+	useCustomCopyTooltip: {
+		type: Boolean,
+		default: false,
+	},
+	copyTooltip: {
+		type: String,
+		default: null,
+	},
 	showLink: {
 		type: Boolean,
 		default: false,
@@ -106,6 +116,14 @@ const props = defineProps({
 	linkPrefix: {
 		type: String,
 		default: '',
+	},
+	useCustomLinkTooltip: {
+		type: Boolean,
+		default: false,
+	},
+	linkTooltip: {
+		type: String,
+		default: null,
 	},
 	placeholder: {
 		type: String,
@@ -159,6 +177,12 @@ const notificationStore = useNotificationsStore();
 
 const { computedLink, computedCopyValue } = usePrefixedValues(props);
 
+const { copyTooltip, linkTooltip, actionTooltip } = useTooltips({
+	clickAction: props.clickAction,
+	useCustomTooltip: props.useCustomCopyTooltip,
+	customTooltip: props.copyTooltip,
+});
+
 
 const inputType = computed(() => {
 	if (['bigInteger', 'integer', 'float', 'decimal'].includes(props.type)) return 'number';
@@ -179,14 +203,6 @@ function valueClickAction(e: Event) {
 	} 
 	// else go on with the default events
 }
-
-
-// TODO: move in composable (together with display)
-const actionTooltip = computed(() => {
-	if (props.clickAction === 'copy' && isCopySupported) return 'Copy value';
-	if (props.clickAction === 'link') return 'Open link';
-});
-
 </script>
 
 

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -101,7 +101,7 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	copyTooltip: {
+	customCopyTooltip: {
 		type: String,
 		default: null,
 	},
@@ -121,7 +121,7 @@ const props = defineProps({
 		type: Boolean,
 		default: false,
 	},
-	linkTooltip: {
+	customLinkTooltip: {
 		type: String,
 		default: null,
 	},
@@ -180,9 +180,9 @@ const { computedLink, computedCopyValue } = usePrefixedValues(props);
 const { copyTooltip, linkTooltip, actionTooltip } = useTooltips({
 	clickAction: props.clickAction,
 	useCustomCopyTooltip: props.useCustomCopyTooltip,
-	copyTooltip: props.copyTooltip,
+	customCopyTooltip: props.customCopyTooltip,
 	useCustomLinkTooltip: props.useCustomLinkTooltip,
-	linkTooltip: props.linkTooltip,
+	customLinkTooltip: props.customLinkTooltip,
 });
 
 

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -179,8 +179,10 @@ const { computedLink, computedCopyValue } = usePrefixedValues(props);
 
 const { copyTooltip, linkTooltip, actionTooltip } = useTooltips({
 	clickAction: props.clickAction,
-	useCustomTooltip: props.useCustomCopyTooltip,
-	customTooltip: props.copyTooltip,
+	useCustomCopyTooltip: props.useCustomCopyTooltip,
+	copyTooltip: props.copyTooltip,
+	useCustomLinkTooltip: props.useCustomLinkTooltip,
+	linkTooltip: props.linkTooltip,
 });
 
 

--- a/src/shared/components/linkWrapper.vue
+++ b/src/shared/components/linkWrapper.vue
@@ -26,7 +26,7 @@
             :target="target"
             @click="activeDialog=false"
           >
-            Open Link
+            Open link
           </v-button >
         </v-card-actions>
       </v-card>

--- a/src/shared/composable/use-tooltips.ts
+++ b/src/shared/composable/use-tooltips.ts
@@ -3,9 +3,11 @@ import { useClipboard } from './use-clipboard';
 import type { ClickAction } from '../types';
 
 type Options = {
-  useCustomTooltip: boolean | null;
-  customTooltip: string | null;
   clickAction: ClickAction;
+  useCustomCopyTooltip: boolean | null;
+  copyTooltip: string | null;
+  useCustomLinkTooltip: boolean | null;
+  linkTooltip: string | null;
 };
 
 
@@ -17,11 +19,19 @@ export function useTooltips(options: Options) {
       return 'Copying not supported';
     }
 
+    if (options.useCustomCopyTooltip) {
+      return options.copyTooltip;
+    }
+
     return 'Copy value';
   });
 
 
   const linkTooltip = computed(() => {
+    if (options.useCustomLinkTooltip) {
+      return options.linkTooltip;
+    }
+
     return 'Open Link';
   });
 

--- a/src/shared/composable/use-tooltips.ts
+++ b/src/shared/composable/use-tooltips.ts
@@ -32,7 +32,7 @@ export function useTooltips(options: Options) {
       return options.customLinkTooltip;
     }
 
-    return 'Open Link';
+    return 'Open link';
   });
 
 

--- a/src/shared/composable/use-tooltips.ts
+++ b/src/shared/composable/use-tooltips.ts
@@ -1,0 +1,48 @@
+import { computed } from 'vue';
+import { useClipboard } from './use-clipboard';
+import type { ClickAction } from '../types';
+
+type Options = {
+  useCustomTooltip: boolean | null;
+  customTooltip: string | null;
+  clickAction: ClickAction;
+};
+
+
+export function useTooltips(options: Options) { 
+  const { isCopySupported } = useClipboard();
+
+  const copyTooltip = computed(() => {
+    if (isCopySupported.value === false) {
+      return 'Copying not supported';
+    }
+
+    return 'Copy value';
+  });
+
+
+  const linkTooltip = computed(() => {
+    return 'Open Link';
+  });
+
+
+  const actionTooltip = computed(() => {
+    if (options.clickAction === 'copy') {
+      return copyTooltip.value;
+    }
+
+    if (options.clickAction === 'link') {
+      return linkTooltip.value;
+    }
+
+    return null;
+  });
+
+
+  return {
+    copyTooltip,
+    linkTooltip,
+    actionTooltip
+  };
+}
+

--- a/src/shared/composable/use-tooltips.ts
+++ b/src/shared/composable/use-tooltips.ts
@@ -5,9 +5,9 @@ import type { ClickAction } from '../types';
 type Options = {
   clickAction: ClickAction;
   useCustomCopyTooltip: boolean | null;
-  copyTooltip: string | null;
+  customCopyTooltip: string | null;
   useCustomLinkTooltip: boolean | null;
-  linkTooltip: string | null;
+  customLinkTooltip: string | null;
 };
 
 
@@ -20,7 +20,7 @@ export function useTooltips(options: Options) {
     }
 
     if (options.useCustomCopyTooltip) {
-      return options.copyTooltip;
+      return options.customCopyTooltip;
     }
 
     return 'Copy value';
@@ -29,7 +29,7 @@ export function useTooltips(options: Options) {
 
   const linkTooltip = computed(() => {
     if (options.useCustomLinkTooltip) {
-      return options.linkTooltip;
+      return options.customLinkTooltip;
     }
 
     return 'Open Link';

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -210,7 +210,7 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field'], 
         hidden: hideBasedOnOtherField(field, configTarget, 'useCustomLinkTooltip', true),
       },
       schema: {
-        default_value: 'Copy link',
+        default_value: 'Open link',
       },
     },
     {

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -1,7 +1,7 @@
 import { DisplayConfig } from '@directus/shared/types';
+import type {ExtensionOptionsContext} from '@directus/types';
 
-
-export function getSharedConfigOptions(isString: boolean) {
+export function getSharedConfigOptions(field: ExtensionOptionsContext['field']) {
   const options: DisplayConfig['options'] = [
     {
       field: 'groupCopySettings',
@@ -90,6 +90,38 @@ export function getSharedConfigOptions(isString: boolean) {
       },
     },
     {
+      field: 'useCustomCopyTooltip',
+      name: 'Custom Tooltip',
+      type: 'boolean',
+      meta: {
+        width: 'half',
+        interface: 'boolean',
+        options: {
+          label: 'Enable',
+        },
+        note: 'Use a custom tooltip for the copy button',
+        group: 'groupCopySettings',
+      },
+      schema: {
+        default_value: false,
+      },
+    },
+    {
+      field: 'copyTooltip',
+      name: 'Tooltip content',
+      type: 'string',
+      meta: {
+        width: 'half',
+        interface: 'system-input-translated-string',
+        group: 'groupCopySettings',
+        note: 'Available placeholder: {{value}}',
+        hidden: !field.meta?.options?.useCustomCopyTooltip,
+      },
+      schema: {
+        default_value: 'Copy value',
+      },
+    },
+    {
       field: 'showLink',
       name: 'Display link icon',
       type: 'boolean',
@@ -147,6 +179,38 @@ export function getSharedConfigOptions(isString: boolean) {
       },
       schema: {
         default_value: '',
+      },
+    },
+    {
+      field: 'useCustomLinkTooltip',
+      name: 'Custom Tooltip',
+      type: 'boolean',
+      meta: {
+        width: 'half',
+        interface: 'boolean',
+        options: {
+          label: 'Enable',
+        },
+        note: 'Use a custom tooltip for the link button',
+        group: 'groupLinkSettings',
+      },
+      schema: {
+        default_value: false,
+      },
+    },
+    {
+      field: 'linkTooltip',
+      name: 'Tooltip content',
+      type: 'string',
+      meta: {
+        width: 'half',
+        interface: 'system-input-translated-string',
+        group: 'groupLinkSettings',
+        note: 'Available placeholder: {{value}}',
+        hidden: !field.meta?.options?.useCustomLinkTooltip,
+      },
+      schema: {
+        default_value: 'Copy link',
       },
     },
     {

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -109,7 +109,7 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field'], 
       },
     },
     {
-      field: 'copyTooltip',
+      field: 'customCopyTooltip',
       name: 'Tooltip content',
       type: 'string',
       meta: {
@@ -200,7 +200,7 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field'], 
       },
     },
     {
-      field: 'linkTooltip',
+      field: 'customLinkTooltip',
       name: 'Tooltip content',
       type: 'string',
       meta: {

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -114,7 +114,6 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field']) 
         width: 'half',
         interface: 'system-input-translated-string',
         group: 'groupCopySettings',
-        note: 'Available placeholder: {{value}}',
         hidden: !field.meta?.options?.useCustomCopyTooltip,
       },
       schema: {
@@ -206,7 +205,6 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field']) 
         width: 'half',
         interface: 'system-input-translated-string',
         group: 'groupLinkSettings',
-        note: 'Available placeholder: {{value}}',
         hidden: !field.meta?.options?.useCustomLinkTooltip,
       },
       schema: {

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -1,7 +1,9 @@
 import { DisplayConfig } from '@directus/shared/types';
 import type {ExtensionOptionsContext} from '@directus/types';
 
-export function getSharedConfigOptions(field: ExtensionOptionsContext['field']) {
+type ConfigTarget = 'display' | 'interface';
+
+export function getSharedConfigOptions(field: ExtensionOptionsContext['field'], configTarget: ConfigTarget) {
   const options: DisplayConfig['options'] = [
     {
       field: 'groupCopySettings',
@@ -114,7 +116,7 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field']) 
         width: 'half',
         interface: 'system-input-translated-string',
         group: 'groupCopySettings',
-        hidden: !field.meta?.options?.useCustomCopyTooltip,
+        hidden: hideBasedOnOtherField(field, configTarget, 'useCustomCopyTooltip', true),
       },
       schema: {
         default_value: 'Copy value',
@@ -205,7 +207,7 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field']) 
         width: 'half',
         interface: 'system-input-translated-string',
         group: 'groupLinkSettings',
-        hidden: !field.meta?.options?.useCustomLinkTooltip,
+        hidden: hideBasedOnOtherField(field, configTarget, 'useCustomLinkTooltip', true),
       },
       schema: {
         default_value: 'Copy link',
@@ -278,4 +280,25 @@ export function getClickActionChoices(isString: boolean) {
 	}
 
 	return selectChoices;
+}
+
+
+/**
+ * Conditionally show/hide a field based on another field's value
+ * 
+ * @param field The field contextOptions
+ * @param configTarget Switch between 'display' and 'interface' config options
+ * @param targetField The field to watch
+ * @param showIfValue The expected value of the target field to show the current field
+ * 
+ * @returns true, if the target field equals the expected value, else false
+ */
+function hideBasedOnOtherField(field: ExtensionOptionsContext['field'], configTarget: ConfigTarget, targetField: string, showIfValue: any) {
+  const options = configTarget === 'display' ? field.meta?.display_options : field.meta?.options;
+
+  if (options?.[targetField] === showIfValue) {
+    return false; // don't hide field
+  }
+
+  return true; // hide field
 }

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,1 @@
+export type ClickAction = 'copy' | 'link' | 'default';


### PR DESCRIPTION
## Scope

What's changed:

- Added copyTooltipLabel field for customizing copy button and field tooltips
- Added openLinkTooltipLabel field for customizing link button and field tooltips
- Updated display.vue to use custom tooltip labels with fallback to default messages
- Updated display configuration in index.ts to include new tooltip label fields
- Both fields are grouped appropriately (copy settings and link settings)
- Maintain backward compatibility with existing implementations

## Potential Risks / Drawbacks

## Review Notes / Questions

### 📝 Checklist

- [ ] I have linked a ticket
- [ ] I have updated the documentation accordingly
- [ ] Request Copilot Review

---

Ticket: 
