### PR TITLE
FIX: sharedOptions types

### DIFF
--- a/src/display/display.test.ts
+++ b/src/display/display.test.ts
@@ -26,6 +26,7 @@ describe('Display.vue - With value', () => {
   const componentWrapper = mount(Display, {
     props: {
       value: value,
+      type: "string",
     },
   });
 
@@ -40,6 +41,7 @@ describe('Display.vue - Enabled Buttons', () => {
   const componentWrapper = mount(Display, {
     props: {
       value: value,
+      type: "string",
       showCopy: true,
       showLink: true,
     }
@@ -62,8 +64,8 @@ describe('Display.vue - Click-Action: copy', () => {
   const componentWrapper = mount(Display, {
     props: {
       value: value,
-      clickAction: "link",
       type: "string",
+      clickAction: "link",
     }
   });
 
@@ -76,6 +78,7 @@ describe('Display.vue - Hide field value', () => {
   const componentWrapper = mount(Display, {
     props: {
       value: value,
+      type: "string",
       clickAction: "link",
       hideFieldValue: true,
     }

--- a/src/display/display.vue
+++ b/src/display/display.vue
@@ -82,16 +82,16 @@ import type { SharedCopyOptionsProps } from '../shared/options/sharedConfigOptio
 
 const props = withDefaults(defineProps<{
 	// Directus default props
-	value: string | null;
+	value?: string | null;
 	type: string;
 
 	// customOptionsBeforeShared
-	hideFieldValue: boolean;
-	clickAction: ClickAction;
+	hideFieldValue?: boolean;
+	clickAction?: ClickAction;
 
 	// customOptionsAfterShared
-	copyButtonLabel: string;
-	linkButtonLabel: string;
+	copyButtonLabel?: string | null;
+	linkButtonLabel?: string | null;
 } & SharedCopyOptionsProps>(), {
 	// Directus default props
 	value: null,
@@ -105,8 +105,8 @@ const props = withDefaults(defineProps<{
 	...sharedOptionsPropsDefaults,
 
 	// customOptionsAfterShared
-	copyButtonLabel: '',
-	linkButtonLabel: '',
+	copyButtonLabel: null,
+	linkButtonLabel: null,
 });
 
 useAppTranslations().loadLocaleMessages();

--- a/src/interface/interface.test.ts
+++ b/src/interface/interface.test.ts
@@ -27,6 +27,7 @@ describe('Interface.vue - With value', () => {
   const componentWrapper = mount(Interface, {
     props: {
       value: value,
+      type: "string",
     },
   });
 
@@ -42,6 +43,7 @@ describe('Interface.vue - With value', () => {
 describe('Interface.vue - Enabled Buttons', () => {
   const componentWrapper = mount(Interface, {
     props: {
+      type: "string",
       showCopy: true,
       showLink: true
     }
@@ -63,6 +65,7 @@ describe('Interface.vue - Enabled Buttons', () => {
 describe('Interface.vue - Click-Action: copy', () => { 
   const componentWrapper = mount(Interface, {
     props: {
+      type: "string",
       clickAction: "link"
     }
   });

--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -83,22 +83,22 @@ import type { SharedCopyOptionsProps } from '../shared/options/sharedConfigOptio
 
 const props = withDefaults(defineProps<{
 	// Directus default props
-	value: string | number | null;
+	value?: string | number | null;
 	type: string;
-	disabled: boolean;
+	disabled?: boolean;
 
 	// interfaceOptions
-	placeholder: string | null;
-	iconLeft: string | null;
-	iconRight: string | null;
+	placeholder?: string | null;
+	iconLeft?: string | null;
+	iconRight?: string | null;
 
 	// readOnlyOptions
-	clickAction: ClickAction;
+	clickAction?: ClickAction;
 
 	// numberOptions
-	min: number | undefined;
-	max: number | undefined;
-	step: number;
+	min?: number | undefined;
+	max?: number | undefined;
+	step?: number;
 } & SharedCopyOptionsProps>(), {
 	// Directus default props
 	value: null,

--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -1,29 +1,30 @@
 import type { ExtensionOptionsContext } from '@directus/types';
 import type { DeepPartial, AppField } from '@directus/types';
+import type { RequiredProps } from '../types';
 
 type ConfigTarget = 'display' | 'interface';
 
 type CopyOptionsProps = {
-  showCopy: boolean;
-  copyPosition: 'start' | 'end';
-  copyPrefix: string;
-  useCustomCopyTooltip: boolean;
-  customCopyTooltip: string;
+  showCopy?: boolean;
+  copyPosition?: 'start' | 'end';
+  copyPrefix?: string;
+  useCustomCopyTooltip?: boolean;
+  customCopyTooltip?: string;
 };
 
 type LinkOptionsProps = {
-  showLink: boolean;
-  linkPosition: 'start' | 'end';
-  linkPrefix: string;
-  useCustomLinkTooltip: boolean;
-  customLinkTooltip: string;
-  openLinkAsNewTab: boolean;
-  openLinkSafeMode: 'never' | 'always';
+  showLink?: boolean;
+  linkPosition?: 'start' | 'end';
+  linkPrefix?: string;
+  useCustomLinkTooltip?: boolean;
+  customLinkTooltip?: string;
+  openLinkAsNewTab?: boolean;
+  openLinkSafeMode?: 'never' | 'always';
 };
 
 export type SharedCopyOptionsProps = CopyOptionsProps & LinkOptionsProps;
 
-const copyOptionsPropsDefaults: CopyOptionsProps = {
+const copyOptionsPropsDefaults: RequiredProps<CopyOptionsProps> = {
   showCopy: false,
   copyPosition: 'end',
   copyPrefix: '',
@@ -31,7 +32,7 @@ const copyOptionsPropsDefaults: CopyOptionsProps = {
   customCopyTooltip: 'Copy value',
 };
 
-const linkOptionsPropsDefaults: LinkOptionsProps = {
+const linkOptionsPropsDefaults: RequiredProps<LinkOptionsProps> = {
   showLink: false,
   linkPosition: 'end',
   linkPrefix: '',

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,1 +1,5 @@
 export type ClickAction = 'copy' | 'link' | 'default';
+
+export type RequiredProps<T> = {
+  [K in keyof T]-?: T[K];
+};


### PR DESCRIPTION
## Scope

What's changed:

- Fix the types of shared options
- With the refactoring we made all props required based on the type definition, however, all with default values aren't required

## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
- [x] I have linked a ticket
- [x] I have updated the documentation accordingly
- [x] Request Copilot Review

---

Ticket: https://lime-exceptional-aces.awork.com/tasks/7850cb15-9487-4c12-ac43-a61b13935921/details
