### PR TITLE
FEAT: default warnExternalLinks to always

### DIFF
--- a/src/shared/options/sharedConfigOptions.ts
+++ b/src/shared/options/sharedConfigOptions.ts
@@ -309,21 +309,22 @@ export function getSharedConfigOptions(field: ExtensionOptionsContext['field'], 
     },
     {
       field: 'openLinkSafeMode',
-      name: 'Warn before following external links',
+      name: 'Link safe mode',
       type: 'string',
       meta: {
         width: 'full',
         interface: 'select-radio',
+        note: 'Choose when to display a confirmation dialog before following external links. The dialog shows the target URL and requires user confirmation.',
         options: {
           choices: [
             { text: 'Never', value: 'never' },
-            { text: 'Always', value: 'always' }
+            { text: 'Always', value: 'always' },
           ],
         },
         group: 'groupLinkSettingsEnabled',
       },
       schema: {
-        default_value: 'never',
+        default_value: 'always',
       },
     },
   ];


### PR DESCRIPTION
## Scope

What's changed:

- Default WarnOnExternalLinks to 'always'


## Potential Risks / Drawbacks

- none, only new fields have new defaults

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
- [x] I have linked a ticket
- [ ] I have updated the documentation accordingly
- [x] Request Copilot Review

---
Ticket: https://lime-exceptional-aces.awork.com/tasks/c806c516-615a-44e3-ae11-296d728b504e/details
