### PR TITLE
FIX: stop event propagation in link-wrapper when used as clickAction

### DIFF
--- a/src/shared/components/ClickActionWrapper.vue
+++ b/src/shared/components/ClickActionWrapper.vue
@@ -44,10 +44,10 @@ const emit = defineEmits<{
 
 function valueClickAction(e: Event) {
   if (props.clickAction === 'copy' && props.disabled) {
-		e.stopPropagation();
-		emit('copy');
+    e.stopPropagation();
+    emit('copy');
   }
-	// else go on with the default events
+  // else go on with the default events
 }
 </script>
 

--- a/src/shared/components/ClickActionWrapper.vue
+++ b/src/shared/components/ClickActionWrapper.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="defa-click-action-wrapper">
+    <!-- NOTE: use @click.stop to prevent parent/item click handlers (e.g., opening the item page) -->
     <link-wrapper
       v-if="clickAction === 'link'"
       :href="computedLink"

--- a/src/shared/components/ClickActionWrapper.vue
+++ b/src/shared/components/ClickActionWrapper.vue
@@ -6,6 +6,7 @@
       :target="openLinkAsNewTab ? '_blank' : '_self'"
       :safeMode="openLinkSafeMode === 'always'"
       v-tooltip="actionTooltip"
+      @click.stop
     >
       <slot />
     </link-wrapper>
@@ -44,7 +45,7 @@ function valueClickAction(e: Event) {
   if (props.clickAction === 'copy' && props.disabled) {
 		e.stopPropagation();
 		emit('copy');
-	} 
+  }
 	// else go on with the default events
 }
 </script>


### PR DESCRIPTION
## Scope

What's changed:

- Stop event propagation in clickAction wrapper on Links


## Potential Risks / Drawbacks

- Lorem ipsum dolor sit amet
- Consectetur adipiscing elit

## Review Notes / Questions

- I would like to lorem ipsum
- Special attention should be paid to dolor sit amet


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
- [x] I have linked a ticket
- [ ] I have updated the documentation accordingly
- [x] Request Copilot Review

---
Ticket: 
https://lime-exceptional-aces.awork.com/tasks/7cf5a7b7-7640-4599-8995-71b6f9c3160d/details

Fixes #77 