### PR TITLE
Bind click handler to copy button

### DIFF
--- a/src/interface/interface.vue
+++ b/src/interface/interface.vue
@@ -38,10 +38,10 @@
 			xLarge
 			data-testid="copy-button"
 			:class="copyPosition === 'start' ? '-defa-order-1' : 'defa-order-1'"
+			@click.stop="copyValue"
 		>
 			<v-icon
 				name="content_copy"
-				@click.stop="copyValue"
 			/>
 		</v-button>
 		


### PR DESCRIPTION
## Scope

What's changed:

Removed the event handler from the inner v-icon and apply it to the surrounding button so the whole button reacts to the user click


## Potential Risks / Drawbacks

## Review Notes / Questions

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
- [x] I have linked a ticket
- [ ] I have updated the documentation accordingly
- [ ] Request Copilot Review

---
Ticket: https://github.com/utomic-media/directus-extension-field-actions/issues/82
